### PR TITLE
Change email hashing from MD5 to SHA256

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -8,7 +8,7 @@ var Integration = require('segmentio-integration');
 var Track = require('segmentio-facade').Track;
 var extend = require('extend');
 var Batch = require('batch');
-var md5 = require('./nanigans/md5');
+var sha256 = require('./nanigans/sha256');
 
 /**
  * Expose `nanigans`
@@ -98,7 +98,7 @@ function params(type, name, track){
   var ret = { type: type };
   ret.name = name;
   ret.user_id = track.userId();
-  if (track.email()) ret.ut1 = md5(track.email());
+  if (track.email()) ret.ut1 = sha256(track.email());
   var products = productParams(track);
 
   if (type === 'purchase'){

--- a/lib/nanigans/sha256.js
+++ b/lib/nanigans/sha256.js
@@ -7,7 +7,7 @@
 var crypto = require('crypto');
 
 /**
- * MD5 hash a string.
+ * SHA256 hash a string.
  *
  * @api private
  * @param {string} string The `string` to hash.
@@ -16,7 +16,7 @@ var crypto = require('crypto');
 
 module.exports = function(string){
   return crypto
-    .createHash('md5')
+    .createHash('sha256')
     .update(string)
     .digest('hex');
 };

--- a/test/index.js
+++ b/test/index.js
@@ -7,7 +7,7 @@
 var Nanigans = require('..');
 var Test = require('segmentio-integration-tester');
 var assert = require('assert');
-var md5 = require('../lib/nanigans/md5');
+var sha256 = require('../lib/nanigans/sha256');
 
 /**
  * Tests.
@@ -95,7 +95,7 @@ describe('Nanigans', function(){
         .track(track)
         .query({ app_id: settings.appId })
         .query({ user_id: 'userId' })
-        .query({ ut1: md5('email') })
+        .query({ ut1: sha256('email') })
         .query({ name: 'product' })
         .query({ sku: '1' })
         .query({ type: 'user' })
@@ -123,7 +123,7 @@ describe('Nanigans', function(){
         .query({ app_id: settings.appId })
         .query({ name: 'add_to_cart' })
         .query({ user_id: 'userId' })
-        .query({ ut1: md5('email') })
+        .query({ ut1: sha256('email') })
         .query({ type: 'user' })
         .end(function(err, responses){
           responses.forEach(function(res){ assert(res.ok); });
@@ -148,7 +148,7 @@ describe('Nanigans', function(){
         .query({ qty: ['1', '2'], sku: ['1', '2'], value: ['1', '2'] })
         .query({ app_id: settings.appId })
         .query({ user_id: 'userId' })
-        .query({ ut1: md5('email') })
+        .query({ ut1: sha256('email') })
         .query({ unique: 'orderId' })
         .query({ type: 'purchase' })
         .query({ name: 'main' })


### PR DESCRIPTION
As of October 1, 2014, Nanigans no longer supports MD5 hashes.
