### PR TITLE
add support for custom parameters

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -10,6 +10,7 @@ var Track = require('segmentio-facade').Track;
 var extend = require('extend');
 var Batch = require('batch');
 var sha256 = require('./nanigans/sha256');
+var qs = require('querystring');
 
 /**
  * Expose `nanigans`
@@ -48,7 +49,7 @@ Nanigans.prototype.track = function(track, fn){
 
   events.forEach(function(event){
     batch.push(function(done){
-      var data = params(event.type, event.name, track);
+      var data = params(event, track);
       data.app_id = self.settings.appId;
       // Nanigans uses advertising_id to associate anonymous users with server side events
       if (advertisingId) data.advertising_id = advertisingId;
@@ -101,6 +102,7 @@ Nanigans.prototype.send = function(payload, type, done){
   if (isMobile) {
     payload.fb_app_id = this.settings.fbAppId;
   }
+
   return this
     .get(isMobile ? '/mobile.php' : '/event.php')
     .query(payload)
@@ -117,22 +119,30 @@ Nanigans.prototype.send = function(payload, type, done){
  * @return {Object}
  */
 
-function params(type, name, track){
-  var ret = { type: type };
-  ret.name = renderByProxy(name, track);
-  ret.user_id = track.userId();
+function params(event, track) {
+  var ret = {
+    type: event.type,
+    name: renderByProxy(event.name, track),
+    user_id: track.userId()
+  };
+
   if (track.email()) ret.ut1 = sha256(track.email());
   var products = productParams(track);
 
-  if (type === 'purchase'){
+  if (event.type === 'purchase') {
     ret.unique = track.orderId();
     extend(ret, products);
   }
 
-  if (type === 'user'){
-    if (name === 'product') ret.sku = products.sku[0];
-    if (name === 'add_to_cart') extend(ret, products);
+  if (event.type === 'user'){
+    if (event.name === 'product') ret.sku = products.sku[0];
+    if (event.name === 'add_to_cart') extend(ret, products);
   }
+
+  Object.keys(event.customParameters).forEach(function(param) {
+    ret[param] = event.customParameters[param];
+  });
+
   return ret;
 }
 

--- a/test/fixtures/track-custom-parameters.json
+++ b/test/fixtures/track-custom-parameters.json
@@ -1,0 +1,25 @@
+{
+  "input": {
+    "type": "track",
+    "timestamp": "2014",
+    "event": "Custom Params",
+    "userId": "user-id",
+    "properties": {
+      "hotelId": "123456"
+    },
+    "context": {
+      "traits": {
+        "email": "email"
+      },
+      "ip": "10.0.0.1"
+    }
+  },
+  "output": {
+    "app_id": 123,
+    "user_id": "user-id",
+    "ut1": "82244417f956ac7c599f191593f7e441a4fafa20a4158fd52e154f1dc4c8ed92",
+    "name": "test_custom",
+    "type": "user",
+    "listing_hotel": "123456"
+  }
+}

--- a/test/index.js
+++ b/test/index.js
@@ -23,12 +23,15 @@ describe('Nanigans', function(){
       mobile: false,
       fbAppId: '345',
       events: [
-        event('testEvent1', 'user', 'invite'),
-        event('testEvent1', 'user', 'register'),
-        event('Completed Order', 'purchase', 'main'),
-        event('Added to Cart', 'user', 'add_to_cart'),
-        event('Viewed Product', 'user', 'product'),
-        event('Watched Game', 'visit', 'watched {{properties.league}} {{properties.sport}} game')
+        event('testEvent1', 'user', 'invite', {}),
+        event('testEvent1', 'user', 'register', {}),
+        event('Completed Order', 'purchase', 'main', {}),
+        event('Added to Cart', 'user', 'add_to_cart', {}),
+        event('Viewed Product', 'user', 'product', {}),
+        event('Watched Game', 'visit', 'watched {{properties.league}} {{properties.sport}} game', {}),
+        event('Custom params', 'purchase', 'test_custom', {
+          'listing_hotel': 'hotel_id'
+        })
       ]
     };
   });
@@ -190,6 +193,18 @@ describe('Nanigans', function(){
           done(err);
         });
     });
+
+    it('should decorate custom parameters', function(done){
+      var data = test.fixture('track-custom-parameters');
+      var spy = sandbox.spy(nanigans, 'get');
+
+      test
+        .track(data.input)
+        .end(function(err, responses){
+          responses.forEach(function(res){ assert(res.ok); });
+          done(err);
+        });
+    });
   });
 
   describe('#page', function(){
@@ -232,6 +247,20 @@ describe('Nanigans', function(){
         });
     });
 
+    it('should send interpolated event names', function(done){
+      var data = test.fixture('track-interpolated');
+      var spy = sandbox.spy(nanigans, 'get');
+
+      test
+        .track(data.input)
+        .query(data.output)
+        .end(function(err, responses){
+          responses.forEach(function(res){ assert(res.ok); });
+          assert(spy.called);
+          done(err);
+        });
+    });
+
     it('should send advertisingId when provided', function(done){
       var data = test.fixture('page-advertising-id');
       var spy = sandbox.spy(nanigans, 'get');
@@ -253,14 +282,16 @@ describe('Nanigans', function(){
  * @param {String} key
  * @param {String} type
  * @param {String} name
+ * @param {Object} map
  */
 
-function event(key, type, name){
+function event(key, type, name, map){
   return {
     key: key,
     value: {
       type: type,
-      name: name
+      name: name,
+      customParameters: map
     }
   };
 }


### PR DESCRIPTION
allows mapping of an arbitrary querystring paramater to an event property value, because nanigans sometimes requests their customers pass through additional values on a key of nanigans' choosing..

For example:

> "Can Segment send generic, custom parameters to Nanigans' endpoint? If yes, how?"
> 
> In this case, we specifically need `hotel_id`, but in the future, a customer might want to pass "AppVersionProperty" or "rate-source"

`hotel_id` may be keyed differently in the customer's event bodies, which is why we're allowing a mapping here

@segment-integrations/core 
