### PR TITLE
Use QS to stringify instead of SuperAgent

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,3 +1,7 @@
+1.5.0 / 2017-05-12
+==================
+
+  * Ensure that sku, value, and qty arrays are sent with indicies (?sku[0]=2&sku[1]=3 instead of ?sku=2&sku=3)
 
 1.4.3 / 2017-04-17
 ==================

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,4 +1,3 @@
-
 'use strict';
 
 /**
@@ -11,6 +10,7 @@ var extend = require('extend');
 var Batch = require('batch');
 var sha256 = require('./nanigans/sha256');
 var unixTime = require('unix-time');
+var qs = require('qs');
 
 /**
  * Expose `nanigans`
@@ -107,8 +107,8 @@ Nanigans.prototype.send = function(payload, type, done){
 
   return this
     .get(isMobile ? '/mobile.php' : '/event.php')
-    .query(payload)
-    .end(this.handle(done));
+    .query(qs.stringify(payload, {encodeValuesOnly: true})) // SuperAgent can't handle arrays properly (given an array a = [1,2] will give ?a=1&a=2 instead of ?a[0]=1&a[1]=2) so we're using qs instead.
+    .end(done);
 };
 
 /**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@segment/integration-nanigans",
-  "version": "1.4.3",
+  "version": "1.5.0",
   "description": "Nanigans server-side integration",
   "author": "Segment <friends@segment.com>",
   "repository": {


### PR DESCRIPTION
As commented, when given an array inside the payload object (for example, payload: {sku = [2, 3]}) it will return a query string like `?sku=2&sku=3` instead of `?sku[0]=2&sku[1]=3`. This fixes this to utilize the correct behavior for Nanigans.